### PR TITLE
Automatically disable Geekbench on less than 2GB memory (fixes #4)

### DIFF
--- a/modules/geekbench.go
+++ b/modules/geekbench.go
@@ -21,8 +21,8 @@ import (
 )
 
 var (
-	vm, err = mem.VirtualMemory()
-	ram     = vm.Total / bytefmt.MEGABYTE
+	vm, _ = mem.VirtualMemory()
+	ram   = vm.Total / bytefmt.MEGABYTE
 )
 
 func init() {


### PR DESCRIPTION
Automatically skips Geekbench on <2GB memory:

```
# ./nixbench -m host -m geekbench
nixbench master - https://github.com/jgillich/nixbench

geekbench
---------
Geekbench was skipped as the system has less than 2GB memory.


host
----
OS        : linux
Platform  : ubuntu 16.04
CPU       : Intel(R) Xeon(R) CPU E5-2630 v2 @ 2.60GHz
Cores     : 1
Clock     : 2599 Mhz
RAM       : 128 MB
```

... and on a system with >2G:

```
# ./nixbench -m host -m geekbench
nixbench master - https://github.com/jgillich/nixbench
^C
[was running; I didn't have time to sit through a Geekbench]
```